### PR TITLE
Add configuration page for Teams

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@microsoft/teams-js": "^1.11.0",
     "axios": "^0.24.0",
     "core-js": "^3.6.5",
     "vue": "^3.0.0",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHashHistory } from 'vue-router'
 import { store } from '../store';
 import Home from '../views/Home.vue'
 import Lobby from '../views/Lobby.vue'
+import Configuration from '../views/Configuration.vue'
 
 const routes = [
   {
@@ -15,7 +16,14 @@ const routes = [
     name: 'Lobby',
     component: Lobby,
     meta: { guest: true } // stops authenticated users from accessing this route
+  },
+  {
+    path: '/configuration',
+    name: 'Configuration',
+    component: Configuration,
+    meta: { guest: true }
   }
+
 
 ]
 

--- a/frontend/src/views/Configuration.vue
+++ b/frontend/src/views/Configuration.vue
@@ -4,9 +4,8 @@
     <form>
       <div class="form-group text-left">
         <label for="nextcloud-url">Nextcloud URL</label>
-        <input type="text" class="form-control" id="nextcloud-url">
+        <input v-model="nextcloudUrl" type="text" class="form-control" id="nextcloud-url">
         </div>
-      <button @click.prevent="saveUrl" class="btn btn-primary">Save</button>
     </form>
   </div>
 </template>
@@ -17,7 +16,8 @@ export default {
   name: "Configuration",
   data() {
     return{
-      context: null
+      context: null,
+      nextcloudUrl: ''
     }
   },
   computed:{
@@ -29,26 +29,23 @@ export default {
     }
   },
   methods:{
-    saveUrl(){
-      console.log("attempting saving")
-      ms.settings.registerOnSaveHandler((saveEvent)=>{
-        console.log(process.env.VUE_APP_NEXTCLOUD_BASE_URL)
-        ms.settings.setSettings({
-          websiteUrl: `${window.location.origin}`,
-          contentUrl: `${window.location.origin}/#/lobby`,
-          entityId: 'nextcloudTab',
-          suggestedDisplayName: "Nextcloud"
-        });
-        saveEvent.notifySuccess();
-      });
-      ms.settings.setValidityState(true);
-    }
   },
   mounted() {
     ms.initialize()
     ms.getContext((context)=>{
       this.context = context;
     });
+    ms.settings.registerOnSaveHandler((saveEvent)=>{
+      console.log("nextcloud url set to ", this.nextcloudUrl)
+      ms.settings.setSettings({
+        websiteUrl: `${window.location.origin}`,
+        contentUrl: `${window.location.origin}/#/lobby`,
+        entityId: 'nextcloudTab',
+        suggestedDisplayName: "Nextcloud"
+      });
+      saveEvent.notifySuccess();
+    });
+    ms.settings.setValidityState(true);
   }
 }
 </script>

--- a/frontend/src/views/Configuration.vue
+++ b/frontend/src/views/Configuration.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="container">
+    <h3>Configuration Page for {{teamName}} in channel: {{channelName}}</h3>
+    <form>
+      <div class="form-group text-left">
+        <label for="nextcloud-url">Nextcloud URL</label>
+        <input type="text" class="form-control" id="nextcloud-url">
+        </div>
+      <button @click.prevent="saveUrl" class="btn btn-primary">Save</button>
+    </form>
+  </div>
+</template>
+
+<script>
+import * as ms from '@microsoft/teams-js';
+export default {
+  name: "Configuration",
+  data() {
+    return{
+      context: null
+    }
+  },
+  computed:{
+    teamName(){
+      return this.context ? this.context.teamName: '';
+    },
+    channelName(){
+      return this.context ? this.context.channelName: '';
+    }
+  },
+  methods:{
+    saveUrl(){
+      console.log("attempting saving")
+      ms.settings.registerOnSaveHandler((saveEvent)=>{
+        console.log(process.env.VUE_APP_NEXTCLOUD_BASE_URL)
+        ms.settings.setSettings({
+          websiteUrl: `${window.location.origin}`,
+          contentUrl: `${window.location.origin}/#/lobby`,
+          entityId: 'nextcloudTab',
+          suggestedDisplayName: "Nextcloud"
+        });
+        saveEvent.notifySuccess();
+      });
+      ms.settings.setValidityState(true);
+    }
+  },
+  mounted() {
+    ms.initialize()
+    ms.getContext((context)=>{
+      this.context = context;
+    });
+  }
+}
+</script>
+
+<style>
+
+</style>


### PR DESCRIPTION
This branch will add a configuration page to the application found at 
`{base_url}/#/configuration`

I was only able to test it with ngrok at the moment, it would be helpful to test how it runs on our online instance https://tms2nc.de
there could still be some bugs here.

To test it yourself (with ngrok)  
edit `public/manifest.json`  
set the `configurationUrl` to the ngrok url (or when online to the url of the server) `{ngrok.url}/#/configuration`  
then create a `nextcloud.zip` containing `manifest.json` and `color.png` and `outline.png`  
upload the zip file to your Teams tenant and add the tab to one of your Channels  

For now the nextcloud url just puts out the value to the console permanent storage needs to be discussed later

