### PR TITLE
file selection like nextcloud

### DIFF
--- a/frontend/src/components/File.vue
+++ b/frontend/src/components/File.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr @click="selectRow">
+  <tr @click.exact="selectRow" @click.ctrl.left="selectRowMulti">
     <td class="text-left">
       <div class="custom-control custom-checkbox">
         <input :checked="isSelected" @change="selectFile" type="checkbox" class="form-check-input selection-check-box"/>
@@ -25,7 +25,7 @@ export default {
   props: ["file"],
   computed: {
     isSelected(){
-        return this.file.selected
+        return this.file.selected;
     }
   },
   updated () {
@@ -42,7 +42,13 @@ export default {
     submitEdit: async function(event) {
         await this.editFileName(this.file, event.currentTarget.value);
     },
-    selectRow: function () {
+    selectRowMulti: function(){
+      this.setFileSelectedInStore(this.file.path, this.file.selected ? false : true)
+    },
+    selectRow: async function (event) {
+      if(!event.target.classList.contains("selection-check-box")){
+          await this.$store.dispatch("setAllFilesUnselected");
+      }
       this.setFileSelectedInStore(this.file.path, this.file.selected ? false : true)
     },
     setFileSelectedInStore: function (path, selected) {
@@ -70,6 +76,7 @@ export default {
       }
     },
   },
+  
 };
 </script>
 
@@ -80,5 +87,9 @@ a:hover {
 .filename-input{
     border: none;
     outline: none
+}
+td{
+  -moz-user-select: none;
+  user-select: none;
 }
 </style>

--- a/frontend/src/components/File.vue
+++ b/frontend/src/components/File.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr @click.exact="selectRow" @click.ctrl.left="selectRowMulti">
+  <tr @click.exact="selectRow" @click.ctrl.left="selectRowMulti" @click.shift.left="selectRowRange">
     <td class="text-left">
       <div class="custom-control custom-checkbox">
         <input :checked="isSelected" @change="selectFile" type="checkbox" class="form-check-input selection-check-box"/>
@@ -36,6 +36,9 @@ export default {
     }
   },
   methods: {
+    selectRowRange(){
+      this.$store.dispatch('selectRange', { child: this.file });
+    },
     selectFile(event){
       this.setFileSelectedInStore(this.file.path, event.currentTarget.checked);
     },

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -46,21 +46,18 @@ export default {
     const store = useStore();
     const keyPressEventHandler =  function(event){
         event.preventDefault();
-        let shouldDeselectOthers = !event.shiftKey;
-        console.log({shouldDeselectOthers});
+        let holdShift = event.shiftKey;
         if(event.key === "ArrowUp"){
-            store.dispatch('moveSelection', { direction: 'previous', deselect: shouldDeselectOthers});
+            store.dispatch('moveSelection', { direction: 'previous', holdShift: holdShift});
         }
         if(event.key === "ArrowDown"){
-            store.dispatch('moveSelection', { direction: 'next', deselect: shouldDeselectOthers});
+            store.dispatch('moveSelection', { direction: 'next', holdShift: holdShift});
         }
     };
     onMounted(() =>{
-        console.log("mounting...")
         window.addEventListener("keydown", keyPressEventHandler);
     });
     onUnmounted(() =>{
-        console.log("unmounting...")
         window.removeEventListener("keydown", keyPressEventHandler);
     });
   },

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -45,7 +45,6 @@ export default {
     // we need to use the composition api to get the store in the setup
     const store = useStore();
     const keyPressEventHandler =  function(event){
-        event.preventDefault();
         let holdShift = event.shiftKey;
         if(event.key === "ArrowUp"){
             store.dispatch('moveSelection', { direction: 'previous', holdShift: holdShift});

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -47,12 +47,15 @@ export default {
     const keyPressEventHandler =  function(event){
         let holdShift = event.shiftKey;
         if(event.key === "ArrowUp"){
+            event.preventDefault();
             store.dispatch('moveSelection', { direction: 'previous', holdShift: holdShift});
         }
         if(event.key === "ArrowDown"){
+            event.preventDefault();
             store.dispatch('moveSelection', { direction: 'next', holdShift: holdShift});
         }
         if(event.key === "Escape"){
+            event.preventDefault();
             store.dispatch("setAllFilesUnselected");
         }
     };

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -32,11 +32,37 @@
 <script>
 // @ is an alias to /src
 import File from "@/components/File.vue";
-
+import { onMounted, onUnmounted } from 'vue';
+import { useStore } from 'vuex';
 export default {
   name: "FileList",
   components: {
     File,
+  },
+  setup () {
+    // since `this` (as in the variable) is not available during setup (or rather is the component instance in an unfinished state, 
+    // also `this` inside the keydown event handler is the window instance)
+    // we need to use the composition api to get the store in the setup
+    const store = useStore();
+    const keyPressEventHandler =  function(event){
+        event.preventDefault();
+        let shouldDeselectOthers = !event.shiftKey;
+        console.log({shouldDeselectOthers});
+        if(event.key === "ArrowUp"){
+            store.dispatch('moveSelection', { direction: 'previous', deselect: shouldDeselectOthers});
+        }
+        if(event.key === "ArrowDown"){
+            store.dispatch('moveSelection', { direction: 'next', deselect: shouldDeselectOthers});
+        }
+    };
+    onMounted(() =>{
+        console.log("mounting...")
+        window.addEventListener("keydown", keyPressEventHandler);
+    });
+    onUnmounted(() =>{
+        console.log("unmounting...")
+        window.removeEventListener("keydown", keyPressEventHandler);
+    });
   },
   props: ["fileList"],
   computed: {

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -53,6 +53,9 @@ export default {
         if(event.key === "ArrowDown"){
             store.dispatch('moveSelection', { direction: 'next', holdShift: holdShift});
         }
+        if(event.key === "Escape"){
+            store.dispatch("setAllFilesUnselected");
+        }
     };
     onMounted(() =>{
         window.addEventListener("keydown", keyPressEventHandler);

--- a/frontend/src/store/modules/files.js
+++ b/frontend/src/store/modules/files.js
@@ -162,6 +162,24 @@ const actions = {
         await dispatch('loadChildrenForPath');
     },
     /**
+     * Select the whole range between lastSelectedChild and the file that was clicked on
+     */
+    selectRange({ getters, commit, dispatch }, { child }){
+      let children = getters.StateChildren;
+      let lastSelection = getters.StateLastSelectedChild;
+      let idxSelection = children.map(c => c.path).indexOf(child.path)
+      if(idxSelection !== -1){
+          let startIdx = lastSelection.index > idxSelection ? idxSelection : lastSelection.index;
+          let stopIdx = lastSelection.index > idxSelection ? lastSelection.index : idxSelection;
+          let direction = startIdx - stopIdx < 0 ? 1: -1;
+          dispatch('setAllFilesUnselected');
+          for(let i = startIdx; i <= stopIdx; i = i + direction){
+            commit('setSelectStateOfChild', { selected: true, index: i});
+          }
+          commit('setLastSelectedChild', { index: stopIdx, child: children[stopIdx] });
+      }
+    },
+    /**
      * Move the selection to the next child in the list or the previous child in the list
      * direction should be either "next" or "previous"
      */

--- a/frontend/src/store/modules/files.js
+++ b/frontend/src/store/modules/files.js
@@ -112,6 +112,12 @@ const actions = {
         });
     },
 
+    setAllFilesUnselected({ getters }) {
+        getters.StateChildren.forEach(child =>{
+            child.selected = false;
+        });
+    },
+
     removeEditField(_, data) {
         data.file.inEdit = false;
     },

--- a/frontend/src/store/modules/files.js
+++ b/frontend/src/store/modules/files.js
@@ -123,8 +123,8 @@ const actions = {
     setAllFilesUnselected({ getters, commit }) {
         getters.StateChildren.forEach((_, index) =>{
             commit('setSelectStateOfChild', { selected: false, index});
-            commit('setLastSelectedChild', null);
         });
+        commit('setLastSelectedChild', null);
     },
 
     removeEditField(_, data) {

--- a/frontend/src/store/modules/files.js
+++ b/frontend/src/store/modules/files.js
@@ -161,12 +161,11 @@ const actions = {
         }
         await dispatch('loadChildrenForPath');
     },
-
     /**
      * Move the selection to the next child in the list or the previous child in the list
      * direction should be either "next" or "previous"
      */
-    moveSelection({ getters, commit, dispatch }, { direction, deselect }){
+    moveSelection({ getters, commit, dispatch }, { direction, holdShift }){
         let lastSelection = getters.StateLastSelectedChild;
         if(lastSelection === null){
             return;
@@ -174,14 +173,19 @@ const actions = {
         let children = getters.StateChildren;
         let currentIndex = lastSelection.index;
         let nextIndex = direction === "next" ? currentIndex+1 : currentIndex-1;
-        if(deselect && (nextIndex >= 0 && nextIndex < children.length )){
+        // don't do anything when the next selection would go outside the range
+        if(nextIndex < 0 || nextIndex >= children.length ){
+            return;
+        }
+        if(!holdShift){
             dispatch('setAllFilesUnselected');
         }
-        if(nextIndex >= 0 && nextIndex < children.length){
-            commit('setSelectStateOfChild', { selected: !deselect, index: currentIndex });
-            commit('setSelectStateOfChild', { selected: true, index: nextIndex});
-            commit('setLastSelectedChild', { index: nextIndex, child: children[nextIndex]});
-        }
+        let nextSelection = children[nextIndex];
+        // when holding shift the last selection doesn't get cleared 
+        // but when going back to the previous selection while holding shift it should deselect the last selection
+        commit('setSelectStateOfChild', { selected: holdShift && !nextSelection.selected , index: currentIndex });
+        commit('setSelectStateOfChild', { selected: true, index: nextIndex});
+        commit('setLastSelectedChild', { index: nextIndex, child: nextSelection});
     }
 };
 


### PR DESCRIPTION
### This merge request is still in Work in Progress so please don't merge yet

I implemented a few changes that weren't part of the Acceptance Criteria but also closer to Sharepoint
- Clicking the checkbox directly doesn't deselect the other children
- clicking the row without holding ctrl will deselect the other files
- clicking the row with holding ctrl will keep the selection
- arrow keys + shift will keep the selection of other files
- arrow keys without shift will move the selection up and down
- clicking while holding shift will now select the whole range between the last selected file and the clicked file

I also made some refactorings inside the `file.js` store because I've seen me and others mutated state inside actions, which shouldn't be done in vuex rather actions should call mutations via `commit` 
I haven't fixed all of them especially not the Edit actions/mutations because #48 will probably change parts of this code in the future so I thought I would not need to invest time into this.

